### PR TITLE
API: use RadialWindow interface

### DIFF
--- a/glass/camb.py
+++ b/glass/camb.py
@@ -9,7 +9,7 @@ import numpy as np
 import camb
 
 
-def camb_tophat_wfunc(z):
+def camb_tophat_weight(z):
     '''Weight function for tophat window functions and CAMB.
 
     This weight function linearly ramps up the redshift at low values,
@@ -19,7 +19,7 @@ def camb_tophat_wfunc(z):
     return np.clip(z/0.1, None, 1.)
 
 
-def matter_cls(pars, lmax, zs, ws, *, limber=False, limber_lmin=100):
+def matter_cls(pars, lmax, ws, *, limber=False, limber_lmin=100):
     '''Compute angular matter power spectra using CAMB.'''
 
     # make a copy of input parameters so we can set the things we need
@@ -46,8 +46,8 @@ def matter_cls(pars, lmax, zs, ws, *, limber=False, limber_lmin=100):
     pars.SourceTerms.counts_evolve = False
 
     sources = []
-    for z, w in zip(zs, ws):
-        s = camb.sources.SplinedSourceWindow(z=z, W=w)
+    for za, wa, _ in ws:
+        s = camb.sources.SplinedSourceWindow(z=za, W=wa)
         sources.append(s)
     pars.SourceWindows = sources
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >=3.6
 install_requires =
     numpy
     camb
-    glass>=2023.1
+    glass>=2023.2
 packages = glass
 
 [options.extras_require]


### PR DESCRIPTION
Uses the `RadialWindow` namedtuple introduced by glass-dev/glass#62 to define the window functions of shells.